### PR TITLE
Adds a Guse sticker to the notifications and make the logic to respect DEBUG env variable

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -6,6 +6,8 @@ on:
     - cron:  '0 13 * * *'
   push:
     branches: master
+  pull_request:
+    branches: master
 
 jobs:
 

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -25,7 +25,7 @@ jobs:
         GCAL_CLI_OAUTH: ${{ secrets.GCAL_CLI_OAUTH }}
         TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
         TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
-	DEBUG: ${{ secrets.DEBUG }}
+        DEBUG: ${{ secrets.DEBUG }}
 
       run: docker build . --file Dockerfile --tag bad:$(date +%s) --build-arg DEBUG="${DEBUG}" --build-arg ICAL_TMPL="${ICAL_TMPL}" --build-arg WEB_CREDS="${WEB_CREDS}" --build-arg GCAL_CLI_CACHE="${GCAL_CLI_CACHE}" --build-arg GCAL_CLI_OAUTH="${GCAL_CLI_OAUTH}" --build-arg TELEGRAM_BOT_TOKEN="${TELEGRAM_BOT_TOKEN}" --build-arg TELEGRAM_CHAT_ID="${TELEGRAM_CHAT_ID}" 
 

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -23,6 +23,7 @@ jobs:
         GCAL_CLI_OAUTH: ${{ secrets.GCAL_CLI_OAUTH }}
         TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
         TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
+	DEBUG: ${{ secrets.DEBUG }}
 
-      run: docker build . --file Dockerfile --tag bad:$(date +%s) --build-arg ICAL_TMPL="${ICAL_TMPL}" --build-arg WEB_CREDS="${WEB_CREDS}" --build-arg GCAL_CLI_CACHE="${GCAL_CLI_CACHE}" --build-arg GCAL_CLI_OAUTH="${GCAL_CLI_OAUTH}" --build-arg TELEGRAM_BOT_TOKEN="${TELEGRAM_BOT_TOKEN}" --build-arg TELEGRAM_CHAT_ID="${TELEGRAM_CHAT_ID}" 
+      run: docker build . --file Dockerfile --tag bad:$(date +%s) --build-arg DEBUG="${DEBUG}" --build-arg ICAL_TMPL="${ICAL_TMPL}" --build-arg WEB_CREDS="${WEB_CREDS}" --build-arg GCAL_CLI_CACHE="${GCAL_CLI_CACHE}" --build-arg GCAL_CLI_OAUTH="${GCAL_CLI_OAUTH}" --build-arg TELEGRAM_BOT_TOKEN="${TELEGRAM_BOT_TOKEN}" --build-arg TELEGRAM_CHAT_ID="${TELEGRAM_CHAT_ID}" 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ ARG GCAL_CLI_CACHE
 ARG GCAL_CLI_OAUTH
 ARG TELEGRAM_BOT_TOKEN
 ARG TELEGRAM_CHAT_ID
-
+ARG DEBUG
 
 RUN if [ -n "$ICAL_TMPL" ]; then echo "$ICAL_TMPL" >/app/ical.tmpl; fi
 RUN if [ -n "$WEB_CREDS" ]; then echo "$WEB_CREDS" >/app/.auth/web-creds; fi


### PR DESCRIPTION
- Adds a function of sending a sticker via Telegram. Moves notifications to Tuesday. Adds Guse sticker to the notification.
- Adds executable attribute to call-for-rsvp.sh. Fixes the problem of broken notifications
- Adds a debug condition for sending the notifications
- Updates GitHub Action Workflow to make the DEBUG secret variable available as an environment variable
